### PR TITLE
Added containers to the Build-Depends list

### DIFF
--- a/Finance-Quote-Yahoo.cabal
+++ b/Finance-Quote-Yahoo.cabal
@@ -13,7 +13,7 @@ cabal-version: 	     >=1.6
 build-type:          Simple
 
 Library 
-  Build-Depends: base >= 3 && < 5,bytestring,http-conduit,network,time,old-locale
+  Build-Depends: base >= 3 && < 5,bytestring,http-conduit,network,time,old-locale, containers
   Exposed-modules:     Finance.Quote.Yahoo
 
 source-repository this


### PR DESCRIPTION
I needed this to get it to build correctly in windows, using ghc version 7.6.3 installed with the haskell platform. Otherwise I would get an error:

```
Finance\Quote\Yahoo.hs:82:18:
    Could not find module `Data.Map'
    It is a member of the hidden package `containers-0.5.0.0'.
    Perhaps you need to add `containers' to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
Failed to install Finance-Quote-Yahoo-0.8.0
```
